### PR TITLE
Feature/cypress testing

### DIFF
--- a/cypress/e2e/favorite_spec.cy.ts
+++ b/cypress/e2e/favorite_spec.cy.ts
@@ -5,5 +5,19 @@ describe('Favorites Page', () => {
         fixture: "pokeData.json"})
         .visit("http://localhost:3000/")
     })
-    
+
+    it('should go to a favorites url (page) when favorites link is clicked', () => {
+        cy.get('a')
+        .should('have.attr', 'href')
+        .then((href) => {
+          cy.visit("http://localhost:3000/favorites")
+        })
+
+        cy.url().should('include', '/favorites')
+    })
+      
+    it('should display no Pokemon cards when no favorite button is clicked', () => {
+        cy.visit("http://localhost:3000/favorites")
+        .get('.single-card-container').should('not.exist');
+    });
 })

--- a/cypress/e2e/favorite_spec.cy.ts
+++ b/cypress/e2e/favorite_spec.cy.ts
@@ -1,0 +1,9 @@
+describe('Favorites Page', () => {
+    beforeEach(() => {
+      cy.intercept("GET", "https://api.pokemontcg.io/v2/cards/", {
+        statusCode: 200,
+        fixture: "pokeData.json"})
+        .visit("http://localhost:3000/")
+    })
+    
+})

--- a/cypress/e2e/main_spec.cy.ts
+++ b/cypress/e2e/main_spec.cy.ts
@@ -2,8 +2,10 @@ describe('Main Page', () => {
   beforeEach(() => {
     cy.intercept("GET", "https://api.pokemontcg.io/v2/cards/", {
       statusCode: 200,
-      fixture: "pokeData.json"})
-    cy.visit("http://localhost:3000/")
+      fixture: "pokeData.json"}).as("pokeDataRequest");
+    cy.visit("http://localhost:3000/");
+    cy.wait("@pokeDataRequest")
+    cy.document().should("have.property", "readyState").and("eq", "complete");
   })
 
   it('should go to a base url', () => {
@@ -12,6 +14,7 @@ describe('Main Page', () => {
 
   it('should render a heading', () => {
     cy.contains("h1", "POKEMON CARDS!")
+    cy.contains("h3", "Browse cards and build your deck")
   })
 
   it('should render a link to navigate to the favorites page', () => {
@@ -30,8 +33,13 @@ describe('Main Page', () => {
     .should('have.length.of.at.least', 3)
   })
 
+  it('should display the title and type for each Pokemon card', () => {
+    cy.get('.cardInfo').eq(0).contains("Ampharos")
+    cy.get('.cardInfo').eq(0).contains("Lightning")
+  })
+
   it('should display each card with a favorite button', () => {
-    cy.get('.single-card-container')
+    cy.get('.favorite-button')
       .contains("Favorite")
   })
 })

--- a/cypress/e2e/main_spec.cy.ts
+++ b/cypress/e2e/main_spec.cy.ts
@@ -27,6 +27,8 @@ describe('Main Page', () => {
     .contains("Aerodactyl")
     cy.get('main')
     .contains("Caterpie")
+
+    cy.get('main').find('.single-card-container').should('have.lengthOf', 3)
   })
 
   it('should display the title and type for each Pokemon card', () => {
@@ -42,6 +44,7 @@ describe('Main Page', () => {
 
   it('should display each card with a favorite button', () => {
     cy.get('.favorite-button')
+      .should('be.visible') 
       .contains("Favorite")
   })
 })

--- a/cypress/e2e/main_spec.cy.ts
+++ b/cypress/e2e/main_spec.cy.ts
@@ -2,10 +2,8 @@ describe('Main Page', () => {
   beforeEach(() => {
     cy.intercept("GET", "https://api.pokemontcg.io/v2/cards/", {
       statusCode: 200,
-      fixture: "pokeData.json"}).as("pokeDataRequest");
-    cy.visit("http://localhost:3000/");
-    cy.wait("@pokeDataRequest")
-    cy.document().should("have.property", "readyState").and("eq", "complete");
+      fixture: "pokeData.json"})
+      .visit("http://localhost:3000/")
   })
 
   it('should go to a base url', () => {
@@ -29,13 +27,17 @@ describe('Main Page', () => {
     .contains("Aerodactyl")
     cy.get('main')
     .contains("Caterpie")
-    cy.get('main')
-    .should('have.length.of.at.least', 3)
   })
 
   it('should display the title and type for each Pokemon card', () => {
     cy.get('.cardInfo').eq(0).contains("Ampharos")
     cy.get('.cardInfo').eq(0).contains("Lightning")
+
+    cy.get('.cardInfo').eq(1).contains("Aerodactyl")
+    cy.get('.cardInfo').eq(1).contains("Colorless")
+
+    cy.get('.cardInfo').eq(2).contains("Caterpie")
+    cy.get('.cardInfo').eq(2).contains("Grass")
   })
 
   it('should display each card with a favorite button', () => {

--- a/cypress/fixtures/pokeData.json
+++ b/cypress/fixtures/pokeData.json
@@ -1,4 +1,23 @@
 [{
+    "image": "https://images.pokemontcg.io/dp3/1_hires.png",
+    "name": "Ampharos",
+    "types": ["Lightning"],
+    "cardId": "dp3-1"
+}, 
+{
+    "image": "https://images.pokemontcg.io/ex12/1_hires.png",
+    "name": "Aerodactyl",
+    "types": ["Colorless"],
+    "cardId": "ex12-1"
+}, 
+{
+    "image": "https://images.pokemontcg.io/mcd19/1_hires.png",
+    "name": "Caterpie",
+    "types": ["Grass"],
+    "cardId": "mcd19-1"
+}]
+
+[{
     "id": "dp3-1",
     "name": "Ampharos",
     "supertype": "Pokémon",

--- a/cypress/fixtures/pokeData.json
+++ b/cypress/fixtures/pokeData.json
@@ -1,23 +1,5 @@
-[{
-    "image": "https://images.pokemontcg.io/dp3/1_hires.png",
-    "name": "Ampharos",
-    "types": ["Lightning"],
-    "cardId": "dp3-1"
-}, 
 {
-    "image": "https://images.pokemontcg.io/ex12/1_hires.png",
-    "name": "Aerodactyl",
-    "types": ["Colorless"],
-    "cardId": "ex12-1"
-}, 
-{
-    "image": "https://images.pokemontcg.io/mcd19/1_hires.png",
-    "name": "Caterpie",
-    "types": ["Grass"],
-    "cardId": "mcd19-1"
-}]
-
-[{
+    "data": [{
     "id": "dp3-1",
     "name": "Ampharos",
     "supertype": "Pokémon",
@@ -308,4 +290,4 @@
             "reverseHoloAvg30": 1.37
         }
     }
-}]
+}]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,13 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "5.0.1",
-        "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
         "@types/react": "^18.2.7",
         "@types/react-router-dom": "^5.3.3",
-        "cypress": "^12.13.0"
+        "cypress": "^12.13.0",
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -17482,15 +17482,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unbox-primitive": {
@@ -31092,9 +31092,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "5.0.1",
-    "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -43,6 +42,7 @@
   "devDependencies": {
     "@types/react": "^18.2.7",
     "@types/react-router-dom": "^5.3.3",
-    "cypress": "^12.13.0"
+    "cypress": "^12.13.0",
+    "typescript": "^5.0.4"
   }
 }

--- a/src/Component/Card/PokemonCard.tsx
+++ b/src/Component/Card/PokemonCard.tsx
@@ -25,7 +25,8 @@ const PokemonCard: React.FC<CardProps> = ( props  : CardProps ) => {
                 <p className="type">{card.types}</p>
             </div>
             { favorited === true ? <>the Button works</> : null }
-            <button 
+            <button
+            className="favorite-button"
             name={card.name} 
             onClick={()=> handleEvent()} >Favorite</button>
         </div>


### PR DESCRIPTION
Added tests for main page, including whether the page displays only three Pokemon cards when using a fixture with three objects. We refactored the fixture data so that it matches the API data structure and appropriately chained assertions so that the cards are rendered on the main page. 

I also created tests for the favorites page, including whether the url changes and any cards exist on the page. 